### PR TITLE
Update log4j to 2.17.0 to address CVE-2021-45105.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.1</version>
+            <version>2.17.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.jsoup/jsoup -->
         <dependency>


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105